### PR TITLE
Customisable Paytrail Payment API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-11
+
+### Added
+
+- Support for custom API endpoints via `PAYTRAIL_API_URL` environment variable (falls back to `https://services.paytrail.com`)
+
 ## [2.0.0] - 2026-02-27
 
 ### Changed

--- a/dist/constants/variable.constant.js
+++ b/dist/constants/variable.constant.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.METHOD = exports.API_ENDPOINT = void 0;
-exports.API_ENDPOINT = 'https://services.paytrail.com';
+exports.API_ENDPOINT = process.env.PAYTRAIL_API_URL || 'https://services.paytrail.com';
 exports.METHOD = {
     GET: 'GET',
     POST: 'POST',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paytrail/paytrail-js-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paytrail/paytrail-js-sdk",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paytrail/paytrail-js-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/constants/variable.constant.ts
+++ b/src/constants/variable.constant.ts
@@ -1,4 +1,4 @@
-export const API_ENDPOINT: string = 'https://services.paytrail.com'
+export const API_ENDPOINT: string = process.env.PAYTRAIL_API_URL || 'https://services.paytrail.com'
 
 export const METHOD: { [key: string]: string } = {
   GET: 'GET',


### PR DESCRIPTION
## Related tickets & documents

## Description

* Add support customisable Paytrail API endpoint. This is for internal testing.